### PR TITLE
Change how $apply is used

### DIFF
--- a/simple-login2/www/js/controllers.js
+++ b/simple-login2/www/js/controllers.js
@@ -21,8 +21,9 @@ angular.module('starter.controllers', [])
                 // 6
                 LoginService.setLoginPattern(pattern);
                 lock.reset();
-                $scope.log_pattern = LoginService.getLoginPattern();
-                $scope.$apply();
+                $scope.$apply(function() {
+                    $scope.log_pattern = LoginService.getLoginPattern();    
+                });
             }
         }
     });


### PR DESCRIPTION
So your code works, but it is not working in the way it should.

So the idea you are doing is...

I execute my pattern stuff, I Create a pattern, I assign it to my scope and since I did that outside the angular context I need to $apply so angular will wake up and manage the bindings for me.

Not a bad idea but there is a little issue. What happens if `LoginService.getLoginPattern()` fails? `localStorage` could give an exception for some reason. What happens here is that the error will get swallowed and you won't notice it. Maybe the idea is to show a little alert / dialog saying.. "Hey, pattern failed for some reason".

$apply is basically a try / catch so what you put inside there will be able to use angular's exception handler in the case that the "wrapped" sentence fails.

It is not likely to fail, but it is easy to apply :)
